### PR TITLE
Add Whisper Notes to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of awesome OpenAI's Whisper
 * [Apple Whisper ASR App](https://apps.apple.com/in/app/whisper-asr/id6444556326)
 * [💬 ASR FastAPI](https://github.com/Wordcab/wordcab-transcribe)
 * [WhisperSubs - Jellyfin plugin for local AI-powered subtitle generation using whisper.cpp](https://github.com/GeiserX/whisper-subs)
+* [Whisper Notes - Offline audio transcription for iOS and macOS with on-device speaker diarization](https://whispernotes.app)
 
 ## Videos
 * [OpenAI Whisper - MultiLingual AI Speech Recognition Live App Tutorial](https://www.youtube.com/watch?v=ywIyc8l1K1Q)


### PR DESCRIPTION
Adds Whisper Notes to Applications. Whisper runs on-device on iPhone and Mac,
with speaker diarization, and it works with no account and no network.

- https://whispernotes.app
- https://apps.apple.com/app/id6447090616