### PR TITLE
Add AI Dictation to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of awesome OpenAI's Whisper
 * [WhisperX: Automatic Speech Recognition with Accurate Word-level Timestamps.](https://github.com/m-bain/whisperX)
 * [stable-ts - Stabilizing Timestamps for Whisper](https://github.com/jianfch/stable-ts)
 * [buzz - Buzz transcribes audio from your computer's microphones to text using OpenAI's Whisper](https://github.com/chidiwilliams/buzz)
+* [AI Dictation - Open-source voice-to-text app for macOS, Windows, iOS, and Android, with Whisper-backed transcription and optional cleanup.](https://github.com/writingmate/aidictation)
 * [whispering - Streaming transcriber with whisper](https://github.com/shirayu/whispering)
 * [whisper-youtube - 🔉 Youtube Videos Transcription with OpenAI's Whisper](https://github.com/ArthurFDLR/whisper-youtube)
 * [Speaker Identification - Pyannote plays and Whisper rhymes](https://github.com/Majdoddin/nlp)


### PR DESCRIPTION
## What changed

- Added AI Dictation to the Applications section as an open-source, cross-platform voice-to-text app.

## Why

AI Dictation uses Whisper-backed transcription, so it fits this list's application scope alongside other end-user transcription tools.

## Validation

- Confirmed there is no existing AI Dictation entry, issue, or pull request.
- Checked the supported platforms and optional cleanup wording against the current project repository.
- Confirmed the project link returns HTTP 200.
- Ran `git diff --check`.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. The entry was prepared with AI assistance and checked against this repository's current contents and recent accepted contributions. AI Dictation's native client source is available under the MIT License.
