### PR TITLE
Add JQSubtitle to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of awesome OpenAI's Whisper
 * [Apple Whisper ASR App](https://apps.apple.com/in/app/whisper-asr/id6444556326)
 * [💬 ASR FastAPI](https://github.com/Wordcab/wordcab-transcribe)
 * [WhisperSubs - Jellyfin plugin for local AI-powered subtitle generation using whisper.cpp](https://github.com/GeiserX/whisper-subs)
+* [JQSubtitle - One-click SRT + SMI subtitles on Windows, rebuilt from word-level timings, with translation into 15 languages via Gemini/Claude or a local Ollama model](https://github.com/i3luegirl/jqsubtitle)
 
 ## Videos
 * [OpenAI Whisper - MultiLingual AI Speech Recognition Live App Tutorial](https://www.youtube.com/watch?v=ywIyc8l1K1Q)


### PR DESCRIPTION
Adding my own project, flagging that up front.

**[JQSubtitle](https://github.com/i3luegirl/jqsubtitle)** — MIT, Windows GUI, one-line PowerShell installer that pulls in Python if it is missing.

faster-whisper large-v3 with word-level timestamps. Rather than trusting Whisper's segment boundaries, it rebuilds the subtitle lines from those word timings, which is what stops run-on lines and mid-sentence cuts. Optional correction and translation into 15 languages via Gemini (free key), Claude, or a local model through Ollama. Writes SMI alongside SRT.

Put it at the end of **Applications**, next to the other subtitle tools. Happy to move it or reword if you'd prefer something shorter.