### PR TITLE
Add ScribeDrop to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of awesome OpenAI's Whisper
 * [Apple Whisper ASR App](https://apps.apple.com/in/app/whisper-asr/id6444556326)
 * [💬 ASR FastAPI](https://github.com/Wordcab/wordcab-transcribe)
 * [WhisperSubs - Jellyfin plugin for local AI-powered subtitle generation using whisper.cpp](https://github.com/GeiserX/whisper-subs)
+* [ScribeDrop - Free Windows GUI for faster-whisper: drag in audio or video, get .txt/.srt/.vtt back, transcribed locally](https://github.com/DJsluxx/scribedrop)
 
 ## Videos
 * [OpenAI Whisper - MultiLingual AI Speech Recognition Live App Tutorial](https://www.youtube.com/watch?v=ywIyc8l1K1Q)


### PR DESCRIPTION
Adds **ScribeDrop** to the `Applications` section.

A free, MIT-licensed Windows desktop GUI for [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (listed above under Model Variants). Drag an audio or video file — or a whole folder — onto the window, pick the model and output formats, and get `.txt`, `.srt` and `.vtt` written next to the source file. It runs on an NVIDIA GPU when one is available and on the CPU when it isn't, and the status line always says which. Audio never leaves the machine; after the one-time model download from Hugging Face it works fully offline.

The list has a lot of CLI tools, web UIs and platform integrations under Applications, but nothing that gives Windows users a plain drag-and-drop window, so this seemed like a gap worth filling.

Entry follows the existing `* [Name - description](link)` format and is appended to the bottom of the section. Checked for duplicates first.

**Disclosure:** I am the author, and it is a new project with 0 stars. There is no CONTRIBUTING file setting a star or age bar — if you'd prefer to wait for a track record, that's entirely fair and I won't re-open.
