### PR TITLE
Add Dictámelo desktop dictation app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A curated list of awesome OpenAI's Whisper
 * [Whisper models on Hugging Face](https://huggingface.co/models?other=whisper) 
 
 ## Applications
+* [Dictámelo - MIT-licensed push-to-talk dictation for macOS and Windows with local Whisper models and optional cloud transcription](https://github.com/sarrazola/dictamelo)
 * [React hook for OpenAI Whisper](https://github.com/chengsokdara/use-whisper)
 * [🎞️ Subtitles generation tool (Web-UI + CLI + Python package)](https://github.com/abdeladim-s/subsai)
 * [Whisper as a Service (GUI and API for OpenAI Whisper)](https://github.com/schibsted/WAAS)


### PR DESCRIPTION
Adds Dictámelo to Applications as a desktop use of local Whisper transcription

I developed the app and am submitting it for consideration
It has an MIT-licensed source repository, in-app model downloads, hold-to-talk input and optional cloud providers

Verified the public license, local-model documentation and v1.0.0 installers for macOS Apple Silicon and Windows x64/ARM64

- https://github.com/sarrazola/dictamelo/blob/main/LICENSE
- https://github.com/sarrazola/dictamelo/blob/main/docs/LOCAL_MODELS.md
- https://github.com/sarrazola/dictamelo/releases/tag/v1.0.0
